### PR TITLE
impl `Send` and `Sync`

### DIFF
--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -31,6 +31,9 @@ pub struct Mmap {
     flags: Flags,
 }
 
+unsafe impl Send for Mmap {}
+unsafe impl Sync for Mmap {}
+
 impl Mmap {
     #[inline]
     pub fn file(&self) -> Option<&File> {

--- a/src/os_impl/windows.rs
+++ b/src/os_impl/windows.rs
@@ -29,6 +29,9 @@ pub struct Mmap {
     flags: Flags,
 }
 
+unsafe impl Send for Mmap {}
+unsafe impl Sync for Mmap {}
+
 impl Mmap {
     #[inline]
     pub fn file(&self) -> Option<&File> {


### PR DESCRIPTION
Since the address referenced by `ptr` is not pointing to the stack or anything thread local `Mmap` should be manually marked as `Send` and `Sync`.

Fixes #5 .