### PR TITLE
with_flags() now ORs the flags

### DIFF
--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -219,12 +219,12 @@ impl MmapOptions {
     }
 
     pub fn with_flags(mut self, flags: MmapFlags) -> Self {
-        self.flags = flags;
+        self.flags |= flags;
         self
     }
 
     pub fn with_unsafe_flags(mut self, flags: UnsafeMmapFlags) -> Self {
-        self.unsafe_flags = flags;
+        self.unsafe_flags |= flags;
         self
     }
 

--- a/src/os_impl/windows.rs
+++ b/src/os_impl/windows.rs
@@ -249,12 +249,12 @@ impl MmapOptions {
     }
 
     pub fn with_flags(mut self, flags: MmapFlags) -> Self {
-        self.flags = flags;
+        self.flags |= flags;
         self
     }
 
     pub unsafe fn with_unsafe_flags(mut self, flags: UnsafeMmapFlags) -> Self {
-        self.unsafe_flags = flags;
+        self.unsafe_flags |= flags;
         self
     }
 


### PR DESCRIPTION
This PR makes all with `with_flags()` methods OR the argument with the current flag setting. This makes it possible for the user to call multiple times `with_flags()` or ORing several flags and prevent accidental cancellation of previous flags.