### PR TITLE
Support DONT_COMMIT to reserve (overcommit) on Windows

### DIFF
--- a/examples/map_nocommit.rs
+++ b/examples/map_nocommit.rs
@@ -1,0 +1,27 @@
+use mmap_rs::{Error, MmapFlags, MmapOptions, UnsafeMmapFlags};
+
+fn main() -> Result<(), Error> {
+    // Allocate a single page of anonymous memory that is private and mutable.
+    let mut mapping = unsafe {
+        MmapOptions::new(MmapOptions::page_size())?
+            .with_flags(MmapFlags::COPY_ON_WRITE)
+            .with_unsafe_flags(UnsafeMmapFlags::DONT_COMMIT)
+            .map_mut()?
+    };
+
+    mapping.commit(0..4).unwrap();
+
+    mapping[0..4].copy_from_slice(b"test");
+
+    let mapping = match mapping.make_read_only() {
+        Ok(mapping) => mapping,
+        Err((_, e)) => {
+            println!("error: {}", e);
+            return Err(e);
+        }
+    };
+
+    println!("mapping: {:x?}", &mapping[0..4]);
+
+    Ok(())
+}

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -47,7 +47,7 @@ bitflags! {
         /// mapped at that address range.
         ///
         /// This is not supported on Microsoft Windows.
-        const MAP_FIXED = 1 << 0;
+        const MAP_FIXED   = 1 << 0;
 
         /// Allows mapping the page as RWX. While this may seem useful for self-modifying code and
         /// JIT engines, it is instead recommended to convert between mutable and executable
@@ -69,7 +69,14 @@ bitflags! {
         /// If the user modified the pages, then executing the code may result in undefined
         /// behavior. To ensure correct behavior a user has to flush the instruction cache after
         /// modifying and before executing the page.
-        const JIT       = 1 << 1;
+        const JIT         = 1 << 1;
+
+        /// Maps the memory mapping without committing physical pages to back it.
+        ///
+        /// On linux this is the default behavior. Pages are committed on first access. On
+        /// Microsoft Windows, it is necessary to expressly not commit the pages at allocation
+        /// time, and to commit them before use.
+        const DONT_COMMIT = 1 << 2;
     }
 
     /// A set of (supported) page sizes.
@@ -326,6 +333,11 @@ macro_rules! mmap_impl {
                 }
 
                 Ok(MmapMut { inner: self.inner })
+            }
+
+            /// Commits the specified sub-range of this mapping
+            pub fn commit(&self, range: Range<usize>) -> Result<(), Error> {
+                self.inner.commit(range)
             }
         }
     };

--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -153,6 +153,10 @@ impl Mmap {
 
         self.do_make(ProtFlags::PROT_READ | ProtFlags::PROT_WRITE | ProtFlags::PROT_EXEC)
     }
+
+    pub fn commit(&self, _range: std::ops::Range<usize>) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl Drop for Mmap {


### PR DESCRIPTION
This PR adds support for a DONT_COMMIT unsafe flag, which allows for reserved but uncommitted allocations on windows. This is known as 'overcommit' on unix, and is the default there.