### PR TITLE
Ensure map_none does not commit pages on Microsoft Windows

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -233,7 +233,7 @@ macro_rules! mmap_impl {
             /// Remaps this memory mapping as inaccessible.
             ///
             /// In case of failure, this returns the ownership of `self`.
-            pub fn make_none(self) -> Result<MmapNone, (Self, Error)> {
+            pub fn make_none(mut self) -> Result<MmapNone, (Self, Error)> {
                 if let Err(e) = self.inner.make_none() {
                     return Err((self, e));
                 }
@@ -244,7 +244,7 @@ macro_rules! mmap_impl {
             /// Remaps this memory mapping as immutable.
             ///
             /// In case of failure, this returns the ownership of `self`.
-            pub fn make_read_only(self) -> Result<Mmap, (Self, Error)> {
+            pub fn make_read_only(mut self) -> Result<Mmap, (Self, Error)> {
                 if let Err(e) = self.inner.make_read_only() {
                     return Err((self, e));
                 }
@@ -255,7 +255,7 @@ macro_rules! mmap_impl {
             /// Remaps this memory mapping as executable.
             ///
             /// In case of failure, this returns the ownership of `self`.
-            pub fn make_exec(self) -> Result<Mmap, (Self, Error)> {
+            pub fn make_exec(mut self) -> Result<Mmap, (Self, Error)> {
                 if let Err(e) = self.inner.make_exec() {
                     return Err((self, e));
                 }
@@ -277,7 +277,7 @@ macro_rules! mmap_impl {
             /// executing the page.
             ///
             /// In case of failure, this returns the ownership of `self`.
-            pub unsafe fn make_exec_no_flush(self) -> Result<Mmap, (Self, Error)> {
+            pub unsafe fn make_exec_no_flush(mut self) -> Result<Mmap, (Self, Error)> {
                 if let Err(e) = self.inner.make_exec() {
                     return Err((self, e));
                 }
@@ -288,7 +288,7 @@ macro_rules! mmap_impl {
             /// Remaps this mapping to be mutable.
             ///
             /// In case of failure, this returns the ownership of `self`.
-            pub fn make_mut(self) -> Result<MmapMut, (Self, Error)> {
+            pub fn make_mut(mut self) -> Result<MmapMut, (Self, Error)> {
                 if let Err(e) = self.inner.make_mut() {
                     return Err((self, e));
                 }
@@ -320,7 +320,7 @@ macro_rules! mmap_impl {
             /// executing the page.
             ///
             /// In case of failure, this returns the ownership of `self`.
-            pub unsafe fn make_exec_mut(self) -> Result<MmapMut, (Self, Error)> {
+            pub unsafe fn make_exec_mut(mut self) -> Result<MmapMut, (Self, Error)> {
                 if let Err(e) = self.inner.make_exec_mut() {
                     return Err((self, e));
                 }

--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -130,23 +130,23 @@ impl Mmap {
         Ok(())
     }
 
-    pub fn make_none(&self) -> Result<(), Error> {
+    pub fn make_none(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_NONE)
     }
 
-    pub fn make_read_only(&self) -> Result<(), Error> {
+    pub fn make_read_only(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_READ)
     }
 
-    pub fn make_exec(&self) -> Result<(), Error> {
+    pub fn make_exec(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_READ | ProtFlags::PROT_EXEC)
     }
 
-    pub fn make_mut(&self) -> Result<(), Error> {
+    pub fn make_mut(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_READ | ProtFlags::PROT_WRITE)
     }
 
-    pub fn make_exec_mut(&self) -> Result<(), Error> {
+    pub fn make_exec_mut(&mut self) -> Result<(), Error> {
         if !self.flags.contains(Flags::JIT) {
             return Err(Error::UnsafeFlagNeeded(UnsafeMmapFlags::JIT));
         }


### PR DESCRIPTION
This PR attempts to tackle the problem outlined in PR #12 by ensuring that `Mmap::map_none()` only reserves a region in the virtual address space, but does not yet allocate any physical pages for that region. This behavior should align well with the behavior of other platforms.

Since the user has no access to the page, it should be safe to simply reserve but not commit the memory mapping avoiding the need for `UnsafeFlags` for this particular use case.

When using one of the functions to change the protection of the memory mapping, and the memory mapping is not yet in a committed state, we commit the pages.

The use case of committing pages with the no access protection will be supported in a separate commit.