### PR TITLE
Implement MemoryAreas::query() to query information about the memory area for a given address

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -117,6 +117,13 @@ impl MemoryAreas<BufReader<File>> {
 
         Ok(Self { inner })
     }
+
+    /// Retrieve information about the memory area corresponding to the virtual address in the
+    /// virtual address space of the current process. Returns `Ok(None)` if no memory has been
+    /// mapped at the given virtual address.
+    pub fn query(address: usize) -> Result<Option<MemoryArea>, Error> {
+        platform::MemoryAreas::query(address)
+    }
 }
 
 impl<B: BufRead> Iterator for MemoryAreas<B> {

--- a/src/os_impl/freebsd.rs
+++ b/src/os_impl/freebsd.rs
@@ -80,6 +80,26 @@ impl MemoryAreas<BufReader<File>> {
             marker: PhantomData,
         })
     }
+
+    pub fn query(address: usize) -> Result<Option<MemoryArea>, Error> {
+        let areas = Self::open(None)?;
+
+        for area in areas {
+            let area = area?;
+
+            if address < area.start() {
+                continue;
+            }
+
+            if area.end() <= address {
+                break;
+            }
+
+            return Ok(Some(area))
+        }
+
+        Ok(None)
+    }
 }
 
 impl<B: BufRead> Iterator for MemoryAreas<B> {

--- a/src/os_impl/linux.rs
+++ b/src/os_impl/linux.rs
@@ -188,6 +188,26 @@ impl MemoryAreas<BufReader<File>> {
 
         Ok(Self { lines })
     }
+
+    pub fn query(address: usize) -> Result<Option<MemoryArea>, Error> {
+        let areas = Self::open(None)?;
+
+        for area in areas {
+            let area = area?;
+
+            if address < area.start() {
+                continue;
+            }
+
+            if area.end() <= address {
+                break;
+            }
+
+            return Ok(Some(area))
+        }
+
+        Ok(None)
+    }
 }
 
 impl<B: BufRead> Iterator for MemoryAreas<B> {


### PR DESCRIPTION
This PR implements `MemoryAreas::query()` to query information about the memory area for a given address as some platforms provide an API that does not require iterating the entire virtual address space. On platforms that do not provide such an API, we simply fallback to iterating the virtual address space until we find the corresponding area for the given address.