### PR TITLE
Add comment documenting the lack of compatiblity of the `STACK` flag on non-unix platforms.

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -26,7 +26,7 @@ bitflags! {
         /// Use huge pages for this allocation.
         const HUGE_PAGES             = 1 << 3;
 
-        /// The region grows downward like a stack.
+        /// The region grows downward like a stack. Only compatible with unix compatible platforms.
         const STACK                  = 1 << 4;
 
         /// The pages will not be included in a core dump.


### PR DESCRIPTION
The `STACK` flag is only compatible with unix compatible platforms, but was not documented. This PR adds documentation so it is immediately clear to the user that this can only be used on UNIX platforms.

Open questions:
* [ ] Should we panic or error when the flag is attempted to be used on windows?
* [ ] Should the `STACK` flag not be compiled in when target_family is not "unix"?