### PR TITLE
Fix size calculation of mapping returned by `split_to`.

### DIFF
--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -179,7 +179,7 @@ impl Mmap {
 
         let ptr = self.ptr;
         self.ptr = unsafe { self.ptr.add(at) };
-        let size = self.size;
+        let size = at;
         self.size -= at;
 
         Ok(Self {

--- a/src/os_impl/windows.rs
+++ b/src/os_impl/windows.rs
@@ -203,7 +203,7 @@ impl Mmap {
 
         let ptr = self.ptr;
         self.ptr = unsafe { self.ptr.add(at) };
-        let size = self.size;
+        let size = at;
         self.size -= at;
 
         Ok(Self {


### PR DESCRIPTION
The returned mapping had a range of `[0, size)` instead of `[0, at)`.