### PR TITLE
extend query API to support ranges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use mmap::*;
 mod tests {
     #[test]
     fn map_none() {
-        use crate::MmapOptions;
+        use crate::{MemoryAreas, MmapOptions, Protection};
 
         let mapping = MmapOptions::new(MmapOptions::page_size())
             .unwrap()
@@ -22,11 +22,17 @@ mod tests {
             .unwrap();
 
         assert!(mapping.as_ptr() != std::ptr::null());
+
+        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+
+        assert!(!region.protection.contains(Protection::READ));
+        assert!(!region.protection.contains(Protection::WRITE));
+        assert!(!region.protection.contains(Protection::EXECUTE));
     }
 
     #[test]
     fn map() {
-        use crate::MmapOptions;
+        use crate::{MemoryAreas, MmapOptions, Protection};
 
         let mapping = MmapOptions::new(MmapOptions::page_size())
             .unwrap()
@@ -34,11 +40,17 @@ mod tests {
             .unwrap();
 
         assert!(mapping.as_ptr() != std::ptr::null());
+
+        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+
+        assert!(region.protection.contains(Protection::READ));
+        assert!(!region.protection.contains(Protection::WRITE));
+        assert!(!region.protection.contains(Protection::EXECUTE));
     }
 
     #[test]
     fn map_mut() {
-        use crate::MmapOptions;
+        use crate::{MemoryAreas, MmapOptions, Protection};
 
         let mut mapping = MmapOptions::new(MmapOptions::page_size())
             .unwrap()
@@ -49,6 +61,12 @@ mod tests {
 
         assert!(mapping.as_ptr() != std::ptr::null());
         assert_eq!(mapping[0], 0x42);
+
+        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+
+        assert!(region.protection.contains(Protection::READ));
+        assert!(region.protection.contains(Protection::WRITE));
+        assert!(!region.protection.contains(Protection::EXECUTE));
     }
 
     #[test]

--- a/src/os_impl/macos.rs
+++ b/src/os_impl/macos.rs
@@ -14,6 +14,7 @@ use nix::unistd::getpid;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::marker::PhantomData;
+use std::ops::Range;
 use std::path::Path;
 
 #[derive(Debug)]
@@ -21,11 +22,12 @@ pub struct MemoryAreas<B> {
     pid: u32,
     task: mach_port_name_t,
     address: mach_vm_address_t,
+    end: Option<usize>,
     marker: PhantomData<B>,
 }
 
 impl MemoryAreas<BufReader<File>> {
-    pub fn open(pid: Option<u32>) -> Result<Self, Error> {
+    pub fn open(pid: Option<u32>, range: Option<Range<usize>>) -> Result<Self, Error> {
         let task = unsafe { mach_task_self() };
 
         if let Some(pid) = pid {
@@ -39,96 +41,10 @@ impl MemoryAreas<BufReader<File>> {
         Ok(Self {
             pid: pid.unwrap_or(getpid().as_raw() as _),
             task,
-            address: 0,
+            address: range.as_ref().map(|range| range.start as mach_vm_address_t).unwrap_or(0),
+            end: range.map(|range| range.end),
             marker: PhantomData,
         })
-    }
-
-    pub fn query(mut address: usize) -> Result<Option<MemoryArea>, Error> {
-        let task = unsafe { mach_task_self() };
-        let mut address = address as u64;
-        let mut size = 0;
-        let mut depth = 0;
-        let mut info: vm_region_submap_info_64 = unsafe { std::mem::zeroed() };
-
-        loop {
-            let mut current_depth = depth;
-            let result = unsafe {
-                mach_vm_region_recurse(
-                    task,
-                    &mut address,
-                    &mut size,
-                    &mut current_depth,
-                    (&mut info as *mut _) as vm_region_recurse_info_t,
-                    &mut vm_region_submap_info_64::count(),
-                )
-            };
-
-            match result {
-                KERN_INVALID_ADDRESS => return Ok(None),
-                KERN_SUCCESS => (),
-                _ => return Err(Error::Mach(result)),
-            }
-
-            if info.is_submap != 0 {
-                depth += 1;
-                continue;
-            }
-
-            break;
-        }
-
-        let start = address as usize;
-        let end = start + size as usize;
-        let range = start..end;
-
-        let mut protection = Protection::empty();
-
-        if info.protection & VM_PROT_READ == VM_PROT_READ {
-            protection |= Protection::READ;
-        }
-
-        if info.protection & VM_PROT_WRITE == VM_PROT_WRITE {
-            protection |= Protection::WRITE;
-        }
-
-        if info.protection & VM_PROT_EXECUTE == VM_PROT_EXECUTE {
-            protection |= Protection::EXECUTE;
-        }
-
-        let share_mode = match info.share_mode {
-            SM_COW | SM_SHARED | SM_TRUESHARED | SM_SHARED_ALIASED => ShareMode::Shared,
-            _ => ShareMode::Private,
-        };
-
-        let mut bytes = [0u8; libc::PATH_MAX as _];
-
-        let result = unsafe {
-            proc_regionfilename(
-                getpid().as_raw() as _,
-                address,
-                bytes.as_mut_ptr() as _,
-                bytes.len() as _,
-            )
-        };
-
-        let path = if result == 0 {
-            None
-        } else {
-            let path = match std::str::from_utf8(&bytes[..result as usize]) {
-                Ok(path) => path,
-                Err(e) => return Err(Error::Utf8(e)),
-            };
-
-            Some((Path::new(path).to_path_buf(), info.offset as u64))
-        };
-
-        Ok(Some(MemoryArea {
-            range,
-            protection,
-            share_mode,
-            path,
-        }))
     }
 }
 
@@ -165,11 +81,15 @@ impl<B: BufRead> Iterator for MemoryAreas<B> {
                 continue;
             }
 
-            depth = 0;
-
             let start = self.address as usize;
             let end = start + size as usize;
             let range = start..end;
+
+            if let Some(end) = self.end {
+                if start >= end {
+                    return None;
+                }
+            }
 
             let mut protection = Protection::empty();
 

--- a/src/os_impl/windows.rs
+++ b/src/os_impl/windows.rs
@@ -503,11 +503,12 @@ use std::marker::PhantomData;
 pub struct MemoryAreas<B> {
     handle: HANDLE,
     address: usize,
+    end: Option<usize>,
     marker: PhantomData<B>,
 }
 
 impl MemoryAreas<BufReader<File>> {
-    pub fn open(pid: Option<u32>) -> Result<Self, Error> {
+    pub fn open(pid: Option<u32>, range: Option<Range<usize>>) -> Result<Self, Error> {
         let handle = match pid {
             Some(id) => unsafe { OpenProcess(PROCESS_ALL_ACCESS, false, id) }?,
             _ => unsafe { GetCurrentProcess() },
@@ -515,82 +516,10 @@ impl MemoryAreas<BufReader<File>> {
 
         Ok(Self {
             handle,
-            address: 0,
+            address: range.as_ref().map(|range| range.start).unwrap_or(0),
+            end: range.map(|range| range.end),
             marker: PhantomData,
         })
-    }
-
-    pub fn query(address: usize) -> Result<Option<MemoryArea>, Error> {
-        let handle = unsafe { GetCurrentProcess() };
-        let mut info = MEMORY_BASIC_INFORMATION::default();
-
-        let size = unsafe {
-            VirtualQueryEx(
-                handle,
-                Some(address as _),
-                &mut info,
-                std::mem::size_of::<MEMORY_BASIC_INFORMATION>(),
-            )
-        };
-
-        if size < std::mem::size_of::<MEMORY_BASIC_INFORMATION>() {
-            return Ok(None);
-        }
-
-        let size = info.RegionSize;
-        let start = info.BaseAddress as usize;
-        let end = start + size;
-        let range = start..end;
-
-        if info.State & MEM_COMMIT == VIRTUAL_ALLOCATION_TYPE(0) {
-            return Ok(None);
-        }
-
-        let copy_on_write =
-            info.Protect == PAGE_EXECUTE_WRITECOPY || info.Protect == PAGE_WRITECOPY;
-
-        let share_mode = if info.Type & MEM_PRIVATE == MEM_PRIVATE {
-            ShareMode::Private
-        } else if copy_on_write {
-            ShareMode::CopyOnWrite
-        } else {
-            ShareMode::Shared
-        };
-
-        let protection = match info.Protect {
-            PAGE_EXECUTE => Protection::EXECUTE,
-            PAGE_EXECUTE_READ => Protection::READ | Protection::EXECUTE,
-            PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY => {
-                Protection::READ | Protection::WRITE | Protection::EXECUTE
-            }
-            PAGE_READONLY => Protection::READ,
-            PAGE_READWRITE | PAGE_WRITECOPY => Protection::READ | Protection::WRITE,
-            _ => Protection::empty(),
-        };
-
-        let mut name = vec![0u16; MAX_PATH as usize];
-
-        let name_size = unsafe {
-            K32GetMappedFileNameW(handle, address as *const std::ffi::c_void, &mut name)
-        };
-
-        let path = if name_size != 0 {
-            let path = widestring::U16CStr::from_slice_truncate(&name).unwrap();
-            let path = path.to_string_lossy();
-
-            let offset = (info.BaseAddress as u64) - (info.AllocationBase as u64);
-
-            Some((PathBuf::from(path), offset))
-        } else {
-            None
-        };
-
-        Ok(Some(MemoryArea {
-            range,
-            protection,
-            share_mode,
-            path,
-        }))
     }
 }
 
@@ -602,6 +531,12 @@ impl<B: BufRead> Iterator for MemoryAreas<B> {
 
         loop {
             let address = self.address;
+
+            if let Some(end) = self.end {
+                if address >= end {
+                    return None;
+                }
+            }
 
             let size = unsafe {
                 VirtualQueryEx(


### PR DESCRIPTION
This PR extends the query API to support ranges and adds additional test cases to test the query API:

 - Clean up the platform-specific code.
 - Add test cases that use the query API.
 - Implement functions to query a specific address or an address range in the same process and in the process for the specified process ID.