### PR TITLE
implement Reserved to represent reserved memory mappings

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -665,6 +665,12 @@ macro_rules! reserved_impl {
                 self.inner.as_ptr()
             }
 
+            /// Yields the length of this mapping.
+            #[inline]
+            pub fn len(&self) -> usize {
+                self.inner.size()
+            }
+
             /// Yields the size of this mapping.
             #[inline]
             pub fn size(&self) -> usize {

--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -148,6 +148,10 @@ impl Mmap {
         self.do_make(ProtFlags::PROT_READ | ProtFlags::PROT_WRITE | ProtFlags::PROT_EXEC)
     }
 
+    pub fn commit(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
     pub fn split_off(&mut self, at: usize) -> Result<Self, Error> {
         if at >= self.size {
             return Err(Error::InvalidOffset);
@@ -403,6 +407,26 @@ impl<'a> MmapOptions<'a> {
             size: size.get(),
             flags,
         })
+    }
+
+    pub fn reserve_none(self) -> Result<Mmap, Error> {
+        self.map_none()
+    }
+
+    pub fn reserve(self) -> Result<Mmap, Error> {
+        self.map()
+    }
+
+    pub fn reserve_exec(self) -> Result<Mmap, Error> {
+        self.map_exec()
+    }
+
+    pub fn reserve_mut(self) -> Result<Mmap, Error> {
+        self.map_mut()
+    }
+
+    pub fn reserve_exec_mut(self) -> Result<Mmap, Error> {
+        self.map_exec_mut()
     }
 
     pub fn map_none(self) -> Result<Mmap, Error> {


### PR DESCRIPTION
This introduces `Reserved`, `ReservedNone` and `ReservedMut` to represent reserved memory mappings that can later on be committed. Similar to `Mmap` objects, these can be split and the permissions of the memory mappings can be changed. In addition, these implement `TryInto` such that they can be converted into their corresponding `Mmap` object, committing the memory mapping on Microsoft Windows.

Since these represent memory mappings without being backed by physical pages, `Reserved` objects do not implement `Deref` or `DerefMut` such that they are inaccessible until committed.

See also PR #12 and PR #13.