### PR TITLE
Extend the README and CHANGELOG and run cargo clippy and fmt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to mmap-rs will be documented in this file.
 
+## 0.6.0
+
+- Add `MemoryAreas::query()` and related functions to query a specific address or address range 
+- Add `Mmap::split_off()` and related functions to split an existing memory mapping at a page boundary.
+- Add `MmapOptions::reserve()` and related functions to reserve memory mappings instead of committing them.
+- Change `MmapOptions::with_file()` to require a reference to the file instead of taking ownership instead.
+- Document flags that may have no operation on platforms that do not support the flag, such as `MmapFlags::STACK` on Microsoft Windows.
+- Use `mach_vm_region_recurse()` on MacOS to recurse into submappings.
+
 ## 0.5.0
 
 - Implement `MmapOptions::page_sizes()` to return the supported page sizes for the platform.

--- a/README.md
+++ b/README.md
@@ -53,4 +53,6 @@ Tier 3 (no CI, but should work):
 - [x] Huge page support.
 - [x] Stack support (also known as `MAP_STACK` on Unix).
 - [x] Support to exclude memory maps from core dumps (on Unix only).
-- [x] Iterator over the memory areas of the current/a given process.
+- [x] Reserve memory mappings, rather than directly committing them.
+- [x] Split memory mappings.
+- [x] Query the memory areas of the current/a given process (for a given address or address range).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
-#![deny(missing_docs, rustdoc::broken_intra_doc_links, missing_debug_implementations )]
+#![deny(
+    missing_docs,
+    rustdoc::broken_intra_doc_links,
+    missing_debug_implementations
+)]
 
 mod areas;
 pub mod error;
@@ -27,7 +31,9 @@ mod tests {
 
         assert!(mapping.as_ptr() != std::ptr::null());
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(!region.protection.contains(Protection::READ));
         assert!(!region.protection.contains(Protection::WRITE));
@@ -49,7 +55,9 @@ mod tests {
 
         assert!(mapping.as_ptr() != std::ptr::null());
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(region.protection.contains(Protection::READ));
         assert!(!region.protection.contains(Protection::WRITE));
@@ -74,7 +82,9 @@ mod tests {
         assert!(mapping.as_ptr() != std::ptr::null());
         assert_eq!(mapping[0], 0x42);
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(region.protection.contains(Protection::READ));
         assert!(region.protection.contains(Protection::WRITE));
@@ -92,7 +102,9 @@ mod tests {
 
         assert!(mapping.as_ptr() != std::ptr::null());
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(!region.protection.contains(Protection::READ));
         assert!(!region.protection.contains(Protection::WRITE));
@@ -110,7 +122,9 @@ mod tests {
 
         assert!(mapping.as_ptr() != std::ptr::null());
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(region.protection.contains(Protection::READ));
         assert!(!region.protection.contains(Protection::WRITE));
@@ -131,7 +145,9 @@ mod tests {
         assert!(mapping.as_ptr() != std::ptr::null());
         assert_eq!(mapping[0], 0x42);
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(region.protection.contains(Protection::READ));
         assert!(region.protection.contains(Protection::WRITE));
@@ -161,7 +177,9 @@ mod tests {
         assert_ne!(mapping.as_ptr(), std::ptr::null());
         assert_eq!(mapping[0], 0x42);
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(region.protection.contains(Protection::READ));
         assert!(!region.protection.contains(Protection::WRITE));
@@ -169,7 +187,7 @@ mod tests {
         #[cfg(not(target_os = "freebsd"))]
         assert!(region.path().is_some());
     }
- 
+
     #[test]
     fn map_file_mut() {
         use crate::{MemoryAreas, MmapFlags, MmapOptions, Protection};
@@ -194,7 +212,9 @@ mod tests {
         mapping.flush(0..MmapOptions::page_size()).unwrap();
         file.as_file_mut().sync_all().unwrap();
 
-        let region = MemoryAreas::query(mapping.as_ptr() as usize).unwrap().unwrap();
+        let region = MemoryAreas::query(mapping.as_ptr() as usize)
+            .unwrap()
+            .unwrap();
 
         assert!(region.protection.contains(Protection::READ));
         assert!(region.protection.contains(Protection::WRITE));
@@ -332,11 +352,13 @@ mod tests {
         let start = left.as_ptr() as usize;
         let end = right.as_ptr() as usize + right.len();
 
-        let mut areas = MemoryAreas::query_range(start..end)
-            .unwrap();
+        let mut areas = MemoryAreas::query_range(start..end).unwrap();
 
         let region = areas.next().unwrap().unwrap();
-        assert_eq!(region.end(), left.as_ptr() as usize + MmapOptions::page_size());
+        assert_eq!(
+            region.end(),
+            left.as_ptr() as usize + MmapOptions::page_size()
+        );
         let mut region = areas.next().unwrap().unwrap();
 
         if region.start() != right.as_ptr() as usize {

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -673,6 +673,12 @@ macro_rules! reserved_impl {
                 self.inner.as_ptr()
             }
 
+            /// Returns `true` if the memory mapping is size 0.
+            #[inline]
+            pub fn is_empty(&self) -> bool {
+                self.inner.size() == 0
+            }
+
             /// Yields the length of this mapping.
             #[inline]
             pub fn len(&self) -> usize {

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -281,7 +281,8 @@ macro_rules! mmap_impl {
             }
 
             /// Remaps this memory mapping as executable, but does not flush the instruction cache.
-            /// Note that this is **unsafe**.
+            ///
+            /// # Safety
             ///
             /// While the x86 and x86-64 architectures guarantee cache coherency between the L1 instruction
             /// and the L1 data cache, other architectures such as Arm and AArch64 do not. If the user
@@ -315,9 +316,10 @@ macro_rules! mmap_impl {
             /// code and JIT engines, it is instead recommended to convert between mutable and executable
             /// mappings using [`Mmap::make_mut()`] and [`MmapMut::make_exec()`] instead.
             ///
-            /// As it may be tempting to use this function, this function has been marked as **unsafe**.
             /// Make sure to read the text below to understand the complications of this function before
             /// using it. The [`UnsafeMmapFlags::JIT`] flag must be set for this function to succeed.
+            ///
+            /// # Safety
             ///
             /// RWX pages are an interesting targets to attackers, e.g. for buffer overflow attacks, as RWX
             /// mappings can potentially simplify such attacks. Without RWX mappings, attackers instead
@@ -516,6 +518,8 @@ impl<'a> MmapOptions<'a> {
     /// [`Mmap::make_exec()`]. Fortunately, Rust provides [`OpenOptionsExt`] that allows you to
     /// open the file with executable access rights. See [`access_mode`] for more information.
     ///
+    /// # Safety
+    ///
     /// This function is marked as **unsafe** as the user should be aware that even in the case
     /// that a file is mapped as immutable in the address space of the current process, it does not
     /// guarantee that there does not exist any other mutable mapping to the file.
@@ -549,8 +553,9 @@ impl<'a> MmapOptions<'a> {
 
     /// The desired configuration of the mapping. See [`UnsafeMmapFlags`] for available options.
     ///
-    /// Note this function is **unsafe** as the flags that can be passed to this function have
-    /// unsafe behavior associated with them.
+    /// # Safety
+    ///
+    /// The flags that can be passed to this function have unsafe behavior associated with them.
     pub unsafe fn with_unsafe_flags(self, flags: UnsafeMmapFlags) -> Self {
         Self {
             inner: self.inner.with_unsafe_flags(flags),
@@ -594,6 +599,8 @@ impl<'a> MmapOptions<'a> {
 
     /// Reserves executable and mutable memory.
     ///
+    /// # Safety
+    ///
     /// See [`MmapOptions::map_exec_mut`] for more information.
     pub unsafe fn reserve_exec_mut(self) -> Result<ReservedMut, Error> {
         Ok(ReservedMut {
@@ -633,9 +640,10 @@ impl<'a> MmapOptions<'a> {
     /// code and JIT engines, it is instead recommended to convert between mutable and executable
     /// mappings using [`Mmap::make_mut()`] and [`MmapMut::make_exec()`] instead.
     ///
-    /// As it may be tempting to use this function, this function has been marked as **unsafe**.
     /// Make sure to read the text below to understand the complications of this function before
     /// using it. The [`UnsafeMmapFlags::JIT`] flag must be set for this function to succeed.
+    ///
+    /// # Safety
     ///
     /// RWX pages are an interesting targets to attackers, e.g. for buffer overflow attacks, as RWX
     /// mappings can potentially simplify such attacks. Without RWX mappings, attackers instead
@@ -715,7 +723,8 @@ macro_rules! reserved_impl {
             }
 
             /// Remaps this memory mapping as executable, but does not flush the instruction cache.
-            /// Note that this is **unsafe**.
+            ///
+            /// # Safety
             ///
             /// While the x86 and x86-64 architectures guarantee cache coherency between the L1 instruction
             /// and the L1 data cache, other architectures such as Arm and AArch64 do not. If the user
@@ -749,9 +758,10 @@ macro_rules! reserved_impl {
             /// code and JIT engines, it is instead recommended to convert between mutable and executable
             /// mappings using [`Mmap::make_mut()`] and [`MmapMut::make_exec()`] instead.
             ///
-            /// As it may be tempting to use this function, this function has been marked as **unsafe**.
             /// Make sure to read the text below to understand the complications of this function before
             /// using it. The [`UnsafeMmapFlags::JIT`] flag must be set for this function to succeed.
+            ///
+            /// # Safety
             ///
             /// RWX pages are an interesting targets to attackers, e.g. for buffer overflow attacks, as RWX
             /// mappings can potentially simplify such attacks. Without RWX mappings, attackers instead

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -813,7 +813,7 @@ macro_rules! reserved_impl {
                 Ok(Self { inner })
             }
         }
-    }
+    };
 }
 
 /// Represents an inaccessible memory mapping in a reserved state, i.e. a memory mapping that is not
@@ -831,9 +831,7 @@ impl TryInto<MmapNone> for ReservedNone {
     fn try_into(mut self) -> Result<MmapNone, Error> {
         self.inner.commit()?;
 
-        Ok(MmapNone {
-            inner: self.inner,
-        })
+        Ok(MmapNone { inner: self.inner })
     }
 }
 
@@ -852,9 +850,7 @@ impl TryInto<Mmap> for Reserved {
     fn try_into(mut self) -> Result<Mmap, Error> {
         self.inner.commit()?;
 
-        Ok(Mmap {
-            inner: self.inner,
-        })
+        Ok(Mmap { inner: self.inner })
     }
 }
 
@@ -873,8 +869,6 @@ impl TryInto<MmapMut> for ReservedMut {
     fn try_into(mut self) -> Result<MmapMut, Error> {
         self.inner.commit()?;
 
-        Ok(MmapMut {
-            inner: self.inner,
-        })
+        Ok(MmapMut { inner: self.inner })
     }
 }

--- a/src/os_impl/macos.rs
+++ b/src/os_impl/macos.rs
@@ -7,7 +7,10 @@ use mach2::{
     traps::{mach_task_self, task_for_pid},
     vm::mach_vm_region_recurse,
     vm_prot::{VM_PROT_EXECUTE, VM_PROT_READ, VM_PROT_WRITE},
-    vm_region::{SM_COW, SM_SHARED, SM_TRUESHARED, SM_SHARED_ALIASED, vm_region_recurse_info_t, vm_region_submap_info_64},
+    vm_region::{
+        vm_region_recurse_info_t, vm_region_submap_info_64, SM_COW, SM_SHARED, SM_SHARED_ALIASED,
+        SM_TRUESHARED,
+    },
     vm_types::mach_vm_address_t,
 };
 use nix::unistd::getpid;
@@ -41,7 +44,10 @@ impl MemoryAreas<BufReader<File>> {
         Ok(Self {
             pid: pid.unwrap_or(getpid().as_raw() as _),
             task,
-            address: range.as_ref().map(|range| range.start as mach_vm_address_t).unwrap_or(0),
+            address: range
+                .as_ref()
+                .map(|range| range.start as mach_vm_address_t)
+                .unwrap_or(0),
             end: range.map(|range| range.end),
             marker: PhantomData,
         })
@@ -139,7 +145,7 @@ impl<B: BufRead> Iterator for MemoryAreas<B> {
                 protection,
                 share_mode,
                 path,
-            }))
+            }));
         }
     }
 }

--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -113,7 +113,7 @@ impl Mmap {
         Ok(())
     }
 
-    fn do_make(&self, protect: ProtFlags) -> Result<(), Error> {
+    fn do_make(&mut self, protect: ProtFlags) -> Result<(), Error> {
         let ptr = self.ptr as *const u8;
         let size = self.size;
 
@@ -124,23 +124,23 @@ impl Mmap {
         Ok(())
     }
 
-    pub fn make_none(&self) -> Result<(), Error> {
+    pub fn make_none(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_NONE)
     }
 
-    pub fn make_read_only(&self) -> Result<(), Error> {
+    pub fn make_read_only(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_READ)
     }
 
-    pub fn make_exec(&self) -> Result<(), Error> {
+    pub fn make_exec(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_READ | ProtFlags::PROT_EXEC)
     }
 
-    pub fn make_mut(&self) -> Result<(), Error> {
+    pub fn make_mut(&mut self) -> Result<(), Error> {
         self.do_make(ProtFlags::PROT_READ | ProtFlags::PROT_WRITE)
     }
 
-    pub fn make_exec_mut(&self) -> Result<(), Error> {
+    pub fn make_exec_mut(&mut self) -> Result<(), Error> {
         if !self.flags.contains(Flags::JIT) {
             return Err(Error::UnsafeFlagNeeded(UnsafeMmapFlags::JIT));
         }

--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -367,12 +367,8 @@ impl<'a> MmapOptions<'a> {
                 size,
                 protect,
                 self.flags(),
-                self.file
-                    .map(|(file, _)| file.as_raw_fd())
-                    .unwrap_or(-1),
-                self.file
-                    .map(|(_, offset)| offset as _)
-                    .unwrap_or(0),
+                self.file.map(|(file, _)| file.as_raw_fd()).unwrap_or(-1),
+                self.file.map(|(_, offset)| offset as _).unwrap_or(0),
             )
         }?;
 

--- a/src/os_impl/windows.rs
+++ b/src/os_impl/windows.rs
@@ -39,13 +39,7 @@ impl Drop for SharedArea {
         if self.flags.contains(SharedFlags::FILE) {
             let _ = unsafe { UnmapViewOfFile(self.ptr as *mut _) };
         } else {
-            let _ = unsafe {
-                VirtualFree(
-                    self.ptr as *mut _,
-                    0,
-                    VIRTUAL_FREE_TYPE(MEM_RELEASE.0),
-                )
-            };
+            let _ = unsafe { VirtualFree(self.ptr as *mut _, 0, VIRTUAL_FREE_TYPE(MEM_RELEASE.0)) };
         }
     }
 }
@@ -179,8 +173,9 @@ impl Mmap {
     }
 
     pub fn make_mut(&mut self) -> Result<(), Error> {
-        let protect = if self.area.flags.contains(SharedFlags::FILE) &&
-            self.flags.contains(Flags::COPY_ON_WRITE) {
+        let protect = if self.area.flags.contains(SharedFlags::FILE)
+            && self.flags.contains(Flags::COPY_ON_WRITE)
+        {
             PAGE_WRITECOPY
         } else {
             PAGE_READWRITE
@@ -400,11 +395,7 @@ impl<'a> MmapOptions<'a> {
 
     /// This is a helper function that goes through the process of setting up the desired memory
     /// mapping given the protection flag.
-    fn do_map(
-        self,
-        protection: PAGE_PROTECTION_FLAGS,
-        mut flags: Flags,
-    ) -> Result<Mmap, Error> {
+    fn do_map(self, protection: PAGE_PROTECTION_FLAGS, mut flags: Flags) -> Result<Mmap, Error> {
         // We have to check whether we can create the file mapping with write and execute
         // permissions. As Microsoft Windows won't let us set any access flags other than those
         // that have been set initially, we have to figure out the full set of access flags that


### PR DESCRIPTION
- Add new features to the README.
- Document new changes for 0.6.0 in the CHANGELOG.
- Run `cargo fmt`.
- Address various issues pointed out by `cargo clippy`.