### PR TITLE
Return the allocation base for memory areas

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -42,6 +42,8 @@ pub enum ShareMode {
 /// Describes a memory area of a process.
 #[derive(Clone, Debug)]
 pub struct MemoryArea {
+    /// The allocation base of the memory area.
+    pub(crate) allocation_base: usize,
     /// The address range of the memory area.
     pub(crate) range: Range<usize>,
     /// The protection with which the memory area has been mapped.
@@ -53,6 +55,12 @@ pub struct MemoryArea {
 }
 
 impl MemoryArea {
+    /// The allocation base of the memory area.
+    #[inline]
+    pub fn allocation_base(&self) -> usize {
+        self.allocation_base
+    }
+
     /// The address range of the memory area.
     #[inline]
     pub fn range(&self) -> &Range<usize> {

--- a/src/os_impl/freebsd.rs
+++ b/src/os_impl/freebsd.rs
@@ -163,6 +163,7 @@ impl<B: BufRead> Iterator for MemoryAreas<B> {
             };
 
             return Some(Ok(MemoryArea {
+                allocation_base: start,
                 range: start..end,
                 protection,
                 share_mode,

--- a/src/os_impl/linux.rs
+++ b/src/os_impl/linux.rs
@@ -123,13 +123,11 @@ where
         optional(path()),
     )
         .map(
-            |(range, _, (protection, share_mode), _, offset, _, _, _, _, _, path)| {
-                MemoryArea {
-                    range,
-                    protection,
-                    share_mode,
-                    path: path.map(|path| (path, offset)),
-                }
+            |(range, _, (protection, share_mode), _, offset, _, _, _, _, _, path)| MemoryArea {
+                range,
+                protection,
+                share_mode,
+                path: path.map(|path| (path, offset)),
             },
         )
 }

--- a/src/os_impl/linux.rs
+++ b/src/os_impl/linux.rs
@@ -124,6 +124,7 @@ where
     )
         .map(
             |(range, _, (protection, share_mode), _, offset, _, _, _, _, _, path)| MemoryArea {
+                allocation_base: range.start,
                 range,
                 protection,
                 share_mode,

--- a/src/os_impl/macos.rs
+++ b/src/os_impl/macos.rs
@@ -142,6 +142,7 @@ impl<B: BufRead> Iterator for MemoryAreas<B> {
             self.address = self.address.saturating_add(size);
 
             return Some(Ok(MemoryArea {
+                allocation_base: range.start,
                 range,
                 protection,
                 share_mode,

--- a/src/os_impl/windows.rs
+++ b/src/os_impl/windows.rs
@@ -709,6 +709,7 @@ impl<B: BufRead> Iterator for MemoryAreas<B> {
             };
 
             return Some(Ok(MemoryArea {
+                allocation_base: info.AllocationBase as usize,
                 range,
                 protection,
                 share_mode,


### PR DESCRIPTION
This PR extends the query API to also return the allocation base of memory areas. On Microsoft Windows, the allocation base is equal to the base address of the memory area that was originally reserved due to how memory allocation works on Microsoft Windows (see PR #26). On Unix, the allocation base is the same as the actual base address of the memory area.