### PR TITLE
Implement Mmap::merge()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,18 @@ pub enum Error {
     #[error("invalid operation")]
     InvalidOperation,
 
+    /// The memory maps must be adjacent.
+    #[error("the memory maps must be adjacent")]
+    MustBeAdjacent,
+
+    /// The attributes of the memory maps do not match.
+    #[error("the memory maps must share the same attributes")]
+    AttributeMismatch,
+
+    /// The backings of the memory maps do not match.
+    #[error("the memory maps must share the same backing")]
+    BackingMismatch,
+
     /// Represents [`std::io::Error`].
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -206,8 +206,8 @@ macro_rules! reserved_mmap_impl {
                 self.inner.size()
             }
 
-            /// Splits the bytes into two at the given byte offset. The byte offset must be page
-            /// size aligned.
+            /// Splits the memory map into two at the given byte offset. The byte offset must be
+            /// page size aligned.
             ///
             /// Afterwards `self` is limited to the range `[0, at)`, and the returning memory
             /// mapping is limited to `[at, len)`.
@@ -217,8 +217,8 @@ macro_rules! reserved_mmap_impl {
                 Ok(Self { inner })
             }
 
-            /// Splits the bytes into two at the given byte offset. The byte offset must be page
-            /// size aligned.
+            /// Splits the memory map into two at the given byte offset. The byte offset must be
+            /// page size aligned.
             ///
             /// Afterwards `self` is limited to the range `[at, len)`, and the returning memory
             /// mapping is limited to `[0, at)`.

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -188,6 +188,18 @@ impl TryInto<PageSize> for PageSizes {
 macro_rules! reserved_mmap_impl {
     ($t:ident) => {
         impl $t {
+            /// Returns the start address of this mapping.
+            #[inline]
+            pub fn start(&self) -> usize {
+                self.inner.as_ptr() as usize
+            }
+
+            /// Returns the end address of this mapping.
+            #[inline]
+            pub fn end(&self) -> usize {
+                self.start() + self.size()
+            }
+
             /// Yields a raw immutable pointer of this mapping.
             #[inline]
             pub fn as_ptr(&self) -> *const u8 {

--- a/src/os_impl/unix.rs
+++ b/src/os_impl/unix.rs
@@ -152,6 +152,16 @@ impl Mmap {
         Ok(())
     }
 
+    pub fn merge(&mut self, other: &Self) -> Result<(), Error> {
+        if self.flags != other.flags {
+            return Err(Error::AttributeMismatch);
+        }
+
+        self.size += other.size;
+
+        Ok(())
+    }
+
     pub fn split_off(&mut self, at: usize) -> Result<Self, Error> {
         if at >= self.size {
             return Err(Error::InvalidOffset);

--- a/src/os_impl/windows.rs
+++ b/src/os_impl/windows.rs
@@ -28,7 +28,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SharedArea {
     ptr: *mut u8,
     flags: SharedFlags,
@@ -215,6 +215,20 @@ impl Mmap {
         }
 
         self.flags |= Flags::COMMITTED;
+
+        Ok(())
+    }
+
+    pub fn merge(&mut self, other: &Self) -> Result<(), Error> {
+        if self.area != other.area {
+            return Err(Error::BackingMismatch);
+        }
+
+        if self.flags != other.flags {
+            return Err(Error::AttributeMismatch);
+        }
+
+        self.size += other.size;
 
         Ok(())
     }


### PR DESCRIPTION
This PR primarily focuses on implementing `Mmap::merge()` to merge split memory maps back into one. On Microsoft Windows, split memory maps can only be merged if they have the same backing due to the limitation described in PR #26. To ensure split and merge works correctly, there is a test case that splits the memory mapping into three parts and tries to merge it in various orders.

In addition, this PR also deduplicates some of the code shared between `Mmap` and `Reserved`, fixes the documentation for the `Mmap::split_off()` and `Mmap::split_to()` functions and adds `Mmap::start()` and `Mmap::end()` as convenience functions to get the start and end address of a memory mapping.