### PR TITLE
Call std::mem::forget() on other for a successful merge

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -250,6 +250,8 @@ macro_rules! reserved_mmap_impl {
                     return Err((e, other));
                 }
 
+                std::mem::forget(other);
+
                 Ok(())
             }
 


### PR DESCRIPTION
Extend the `split_and_merge()` test to confirm that nothing got dropped or released. Also call `std::mem::forget()` on other for a successful merge.