### PR TITLE
Specify 1.67.1 as MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,32 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, ubuntu-latest, macos-latest]
+        toolchain:
+          - stable
+          - 1.67
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.toolchain }}
+        override: true
+        components: rustfmt, clippy
+        target: ${{ matrix.target.rust }}
     - name: Build
       run: cargo build
     - name: Run tests
       run: cargo test
-    - name: Verify MSRV
-      run: cargo install cargo-msrv && cargo msrv verify
 
   cross-windows:
     runs-on: windows-2019
     strategy:
       matrix:
+        toolchain:
+          - stable
+          - 1.67
         target:
           - rust: 'aarch64-pc-windows-msvc'
           - rust: 'i686-pc-windows-msvc'
@@ -37,7 +48,7 @@ jobs:
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ matrix.toolchain }}
         override: true
         components: rustfmt, clippy
         target: ${{ matrix.target.rust }}
@@ -48,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        toolchain:
+          - stable
+          - 1.67
         target:
         - arch: 'aarch64'
           rust: 'aarch64-unknown-linux-gnu'
@@ -64,7 +78,7 @@ jobs:
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ matrix.toolchain }}
         override: true
         components: rustfmt, clippy
         target: ${{ matrix.target.rust }}
@@ -93,6 +107,9 @@ jobs:
         os:
         - release: '13.1'
         - release: '12.3'
+        toolchain:
+          - stable
+          - 1.67
 
     steps:
     - uses: actions/checkout@v3
@@ -107,6 +124,8 @@ jobs:
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal -y
           . "$HOME/.cargo/env"
+          rustup install ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
           cargo build
           cargo test
           cargo install cargo-msrv && cargo msrv verify
@@ -115,6 +134,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        toolchain:
+          - stable
+          - 1.67
         target:
         - rust: 'aarch64-linux-android'
         - rust: 'armv7-linux-androideabi'
@@ -126,7 +148,7 @@ jobs:
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ matrix.toolchain }}
         override: true
         components: rustfmt, clippy
         target: ${{ matrix.target.rust }}
@@ -135,13 +157,18 @@ jobs:
 
   aarch64-apple-ios:
     runs-on: macos-12
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - 1.67
 
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ matrix.toolchain }}
         override: true
         components: rustfmt, clippy
         target: aarch64-apple-ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,6 @@ jobs:
           rustup default ${{ matrix.toolchain }}
           cargo build
           cargo test
-          cargo install cargo-msrv && cargo msrv verify
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       run: cargo build
     - name: Run tests
       run: cargo test
+    - name: Verify MSRV
+      run: cargo install cargo-msrv && cargo msrv verify
 
   cross-windows:
     runs-on: windows-2019
@@ -107,6 +109,7 @@ jobs:
           . "$HOME/.cargo/env"
           cargo build
           cargo test
+          cargo install cargo-msrv && cargo msrv verify
 
   android:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to mmap-rs will be documented in this file.
 
 ## 0.6.1
 
-- Added the MSRV (1.67.1).
+- Added the MSRV (1.67).
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to mmap-rs will be documented in this file.
 
+## 0.6.1
+
+- Added the MSRV (1.67.1).
+
 ## 0.6.0
 
 - Implemented `Debug` for all public types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "A cross-platform and safe Rust API to create and manage memory ma
 homepage = "https://codentium.com"
 repository = "https://github.com/StephanvanSchaik/mmap-rs"
 keywords = ["mmap", "memory", "mapping", "VirtualAlloc"]
-rust-version = "1.67.1"
+rust-version = "1.67"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmap-rs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Stephan van Schaik <stephan@synkhronix.com>"]
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "A cross-platform and safe Rust API to create and manage memory ma
 homepage = "https://codentium.com"
 repository = "https://github.com/StephanvanSchaik/mmap-rs"
 keywords = ["mmap", "memory", "mapping", "VirtualAlloc"]
+rust-version = "1.67.1"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
This fixes issue #37. The current MSRV is 1.67.1 (from running `cargo msrv`), specify that in Cargo.toml, extend the workflow to verify the current MSRV keeps working and release version 0.6.1.